### PR TITLE
Update OpenCV dependencies

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,16 +11,15 @@ jobs:
       linux_64_python3.6.____cpython:
         CONFIG: linux_64_python3.6.____cpython
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
       linux_64_python3.7.____cpython:
         CONFIG: linux_64_python3.7.____cpython
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
       linux_64_python3.8.____cpython:
         CONFIG: linux_64_python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
-    maxParallel: 8
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
   timeoutInMinutes: 360
 
   steps:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -17,7 +17,6 @@ jobs:
       osx_64_python3.8.____cpython:
         CONFIG: osx_64_python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
-    maxParallel: 8
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/linux_64_python3.6.____cpython.yaml
+++ b/.ci_support/linux_64_python3.6.____cpython.yaml
@@ -1,3 +1,5 @@
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -7,7 +9,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-comp7
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_python3.7.____cpython.yaml
@@ -1,3 +1,5 @@
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -7,7 +9,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-comp7
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_python3.8.____cpython.yaml
@@ -1,3 +1,5 @@
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -7,7 +9,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-comp7
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_python3.6.____cpython.yaml
+++ b/.ci_support/osx_64_python3.6.____cpython.yaml
@@ -7,7 +7,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '10'
+- '11'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:

--- a/.ci_support/osx_64_python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_python3.7.____cpython.yaml
@@ -7,7 +7,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '10'
+- '11'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:

--- a/.ci_support/osx_64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_python3.8.____cpython.yaml
@@ -7,7 +7,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '10'
+- '11'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -19,7 +19,7 @@ conda-build:
 
 CONDARC
 
-conda install --yes --quiet conda-forge-ci-setup=3 conda-build pip -c conda-forge
+conda install --yes --quiet "conda-forge-ci-setup=3" conda-build pip -c conda-forge
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -37,13 +37,25 @@ source run_conda_forge_build_setup
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
-conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-    --suppress-variables ${EXTRA_CB_OPTIONS:-} \
-    --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
-validate_recipe_outputs "${FEEDSTOCK_NAME}"
 
-if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
-    upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}"  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
+    if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
+        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
+    fi
+    conda debug "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+        ${EXTRA_CB_OPTIONS:-} \
+        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
+    # Drop into an interactive shell
+    /bin/bash
+else
+    conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+        --suppress-variables ${EXTRA_CB_OPTIONS:-} \
+        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
+    validate_recipe_outputs "${FEEDSTOCK_NAME}"
+
+    if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
+        upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}"  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+    fi
 fi
 
 touch "${FEEDSTOCK_ROOT}/build_artifacts/conda-forge-build-done-${CONFIG}"

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -74,6 +74,8 @@ docker run ${DOCKER_RUN_ARGS} \
            -e CI \
            -e FEEDSTOCK_NAME \
            -e CPU_COUNT \
+           -e BUILD_WITH_CONDA_DEBUG \
+           -e BUILD_OUTPUT_ID \
            -e BINSTAR_TOKEN \
            -e FEEDSTOCK_TOKEN \
            -e STAGING_BINSTAR_TOKEN \

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -23,7 +23,7 @@ source ${HOME}/miniforge3/etc/profile.d/conda.sh
 conda activate base
 
 echo -e "\n\nInstalling conda-forge-ci-setup=3 and conda-build."
-conda install -n base --quiet --yes conda-forge-ci-setup=3 conda-build pip
+conda install -n base --quiet --yes "conda-forge-ci-setup=3" conda-build pip
 
 
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@ Home: https://github.com/leiyangleon/autoRIFT
 
 Package license: Apache-2.0
 
-Feedstock license: BSD-3-Clause
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/autorift-feedstock/blob/master/LICENSE.txt)
 
 Summary: Fast pixel displacement estimation from remote sensing imagery
 
+Development: https://github.com/leiyangleon/autoRIFT
 
+Documentation: https://github.com/leiyangleon/autoRIFT
 
 Current build status
 ====================

--- a/build-locally.py
+++ b/build-locally.py
@@ -12,6 +12,10 @@ from argparse import ArgumentParser
 def setup_environment(ns):
     os.environ["CONFIG"] = ns.config
     os.environ["UPLOAD_PACKAGES"] = "False"
+    if ns.debug:
+        os.environ["BUILD_WITH_CONDA_DEBUG"] = "1"
+        if ns.output_id:
+            os.environ["BUILD_OUTPUT_ID"] = ns.output_id
 
 
 def run_docker_build(ns):
@@ -51,6 +55,14 @@ def verify_config(ns):
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
+    p.add_argument(
+        "--debug",
+        action="store_true",
+        help="Setup debug environment using `conda debug`",
+    )
+    p.add_argument(
+        "--output-id", help="If running debug, specify the output to setup."
+    )
 
     ns = p.parse_args(args=args)
     verify_config(ns)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - opencv
   run:
     - python
-    - opencv
+    - {{ pin_compatible('opencv') }}
     - scipy
     - scikit-image
     - gdal

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 
 build:
   number: 1
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install --global-option=build_ext --global-option="-I${PREFIX}/include/opencv4" . -vv
   skip: true  # [win or py2k]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
   skip: true  # [win or py2k]
 
@@ -24,12 +24,10 @@ requirements:
   host:
     - python
     - pip
-    - libopencv 3.4
-    - opencv 3.4
+    - opencv
   run:
     - python
-    - opencv 3.4
-    - libopencv 3.4
+    - opencv
     - scipy
     - scikit-image
     - gdal


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
### Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
### Why
This relaxes the `opencv` host dependency (previously pinned at 3.4) as it works with both OpenCV 3.4 and 4, and pins the runtime dependency to the version of OpenCV autoRIFT was built against. 

I've also eliminated `libopencv` from the recipe as [it's a pinned dependency of `opencv`](https://github.com/conda-forge/opencv-feedstock/blob/master/recipe/meta.yaml#L178)
