### PR TITLE
[ci skip] adding user @jhkennedy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @alex-s-gardner @leiyangleon @piyushrpt
+* @jhkennedy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,6 +54,7 @@ about:
 
 extra:
   recipe-maintainers:
+    - jhkennedy
     - leiyangleon
     - piyushrpt
     - alex-s-gardner


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @jhkennedy as instructed in #33.

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.

Fixes #33